### PR TITLE
Setting audience on auth request

### DIFF
--- a/packages/frontend/.env
+++ b/packages/frontend/.env
@@ -1,9 +1,7 @@
 # Default environment variables.  Override in prod if needed.
 
-# Not a secret
 REACT_APP_AUTH0_DOMAIN="dev-71ee1qantl30gloi.us.auth0.com"
-
-# Not a secret
 REACT_APP_AUTH0_CLIENTID="gWVmaB2m8JYW7QeJeLgAscP0SWdLgKj6"
+REACT_APP_AUTH0_AUDIENCE="https://dev.vvc.sonnex.name/api"
 
 REACT_APP_API_BASE_PATH="https://dev.vvc.sonnex.name"

--- a/packages/frontend/src/components/AuthProvider/AuthProvider.tsx
+++ b/packages/frontend/src/components/AuthProvider/AuthProvider.tsx
@@ -4,14 +4,16 @@ type AuthProviderProps = React.PropsWithChildren;
 export const AuthProvider = ({ children }: AuthProviderProps) => {
   const domain = process.env.REACT_APP_AUTH0_DOMAIN;
   const clientId = process.env.REACT_APP_AUTH0_CLIENTID;
+  const audience = process.env.REACT_APP_AUTH0_AUDIENCE;
 
-  if (!domain || !clientId) {
+  if (!domain || !clientId || !audience) {
     throw new Error("Authorization settings missing");
   }
   return (
     <Auth0Provider
       domain={domain}
       clientId={clientId}
+      audience={audience}
       redirectUri={window.location.origin}
     >
       {children}


### PR DESCRIPTION
This makes the access token transparent so we can pull claims out of it. I needed to create a new "API" in Auth0 for this.